### PR TITLE
Adicionado pacote de idiomas

### DIFF
--- a/src/main/java/core/DataYaml.java
+++ b/src/main/java/core/DataYaml.java
@@ -2,6 +2,7 @@ package core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import localization.MessageParser;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 
@@ -13,9 +14,10 @@ import java.util.*;
 @Log4j2
 public class DataYaml{
 
+    private static MessageParser parser = new MessageParser();
+
     private static File getYamlDataFile(String fileName){
-        log.info(String.format("Recuperando o caminho do arquivo %s.yml da massa de dados do ambiente %s"
-                ,fileName,System.getProperty("env")));
+        log.info(parser.parse("data.yaml.get.file", new Object[]{fileName,System.getProperty("env")}));
         return new File("./src/test/resources/data/"+System.getProperty("env")+"/"+fileName+".yml");
     }
 
@@ -27,10 +29,10 @@ public class DataYaml{
         Map<String , Object> maps;
         try {
             maps = (LinkedHashMap<String, Object>) mapper.readValue(getYamlDataFile(fileName), Map.class);
-            log.error(String.format("Retornando objeto HashMap com a massa de dados do arquivo %s.yml com titulo %s",fileName,titulo));
+            log.info(parser.parse("data.yaml.return", new Object[]{fileName,titulo}));
             return  (LinkedHashMap<String, String>) maps.get(titulo);
         } catch (IOException e) {
-            log.error(String.format("Erro ao tentar ler o arquivo de massa %s.yaml - stackTrace: %s",fileName,e));
+            log.error(parser.parse("data.yaml.error", new Object[]{fileName,e}));
             throw new Exception(e);
         }
     }

--- a/src/main/java/localization/MessageParser.java
+++ b/src/main/java/localization/MessageParser.java
@@ -1,0 +1,21 @@
+package localization;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+public class MessageParser {
+
+    private static ResourceBundle prop = ResourceBundle.getBundle("log4j2");
+    private static ResourceBundle bundle = ResourceBundle.getBundle("messages",
+            Locale.forLanguageTag(prop.getString("language")));
+
+    public String parse(String label, Object[] params) {
+        MessageFormat formatter = new MessageFormat(bundle.getString(label));
+        return formatter.format(params);
+    }
+
+    public String parse(String label) {
+        return bundle.getString(label);
+    }
+}

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -17,3 +17,6 @@ rootLogger.level = debug
 rootLogger.appenderRefs = stdout
 #rootLogger.appenderRef.stdout.ref = STDOUT
 rootLogger.appenderRef.file.ref = LOGFILE
+
+#supported en-US or pt-BR
+language=pt-BR

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,0 +1,10 @@
+# src.main.java.data.DataYaml.java
+data.yaml.get.file:Getting path of file {0}.yaml with test data from {1} environment
+data.yaml.return:Returning HashMap object with test data from file {0} with title {1}
+data.yaml.error:Error while trying to read data file {0}.yaml - stackTrace: {1}
+
+# src.test.java.hooks
+hook.test.started:TEST STARTED: {0}
+hook.test.build:Building SPEC object with global request settings
+hook.test.ended:TEST ENDED: {0}
+hook.test.status:TEST STATUS: {0}

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,7 +1,7 @@
 # src.main.java.data.DataYaml.java
-data.yaml.get.file:Getting path of file {0}.yaml with test data from {1} environment
-data.yaml.return:Returning HashMap object with test data from file {0} with title {1}
-data.yaml.error:Error while trying to read data file {0}.yaml - stackTrace: {1}
+data.yaml.get.file:Getting path of file {0}.yml with test data from {1} environment
+data.yaml.return:Returning HashMap object with test data from file {0}.yml with title {1}
+data.yaml.error:Error while trying to read data file {0}.yml - stackTrace: {1}
 
 # src.test.java.hooks
 hook.test.started:TEST STARTED: {0}

--- a/src/main/resources/messages_pt.properties
+++ b/src/main/resources/messages_pt.properties
@@ -1,10 +1,10 @@
 # src.main.java.data.DataYaml.java
 data.yaml.get.file:Recuperando o caminho do arquivo {0}.yml da massa de dados do ambiente {1}
-data.yaml.return:Retornando objeto HashMap com a massa de dados do arquivo {0}.yml com t\u00EDtulo {1}"
-data.yaml.error:Erro ao tentar ler o arquivo de massa {0}.yaml - stackTrace: {1}
+data.yaml.return:Retornando objeto HashMap com a massa de dados do arquivo {0}.yml com título {1}"
+data.yaml.error:Erro ao tentar ler o arquivo de massa {0}.yml - stackTrace: {1}
 
 # src.test.java.hooks
 hook.test.started:TESTE INICIADO: {0}
-hook.test.build:Construindo objeto SPEC com as defini\u00E7\u00F5es globais de requisi\u00E7\u00E3o
+hook.test.build:Construindo objeto SPEC com as definições globais de requisição
 hook.test.ended:TESTE FINALIZADO: {0}
 hook.test.status:STATUS DO TESTE: {0}

--- a/src/main/resources/messages_pt.properties
+++ b/src/main/resources/messages_pt.properties
@@ -1,0 +1,10 @@
+# src.main.java.data.DataYaml.java
+data.yaml.get.file:Recuperando o caminho do arquivo {0}.yml da massa de dados do ambiente {1}
+data.yaml.return:Retornando objeto HashMap com a massa de dados do arquivo {0}.yml com t\u00EDtulo {1}"
+data.yaml.error:Erro ao tentar ler o arquivo de massa {0}.yaml - stackTrace: {1}
+
+# src.test.java.hooks
+hook.test.started:TESTE INICIADO: {0}
+hook.test.build:Construindo objeto SPEC com as defini\u00E7\u00F5es globais de requisi\u00E7\u00E3o
+hook.test.ended:TESTE FINALIZADO: {0}
+hook.test.status:STATUS DO TESTE: {0}

--- a/src/test/java/hooks/Hook.java
+++ b/src/test/java/hooks/Hook.java
@@ -8,15 +8,18 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.filter.log.ResponseLoggingFilter;
 import io.restassured.http.ContentType;
+import localization.MessageParser;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class Hook extends Spec {
 
+    private static MessageParser parser = new MessageParser();
+
     @Before
     public void init(Scenario scenario) {
-        log.info(String.format("TESTE INICIADO: %s",scenario.getName()));
-        log.info("Construindo objeto SPEC com as definições globais de requisição");
+        log.info(parser.parse("hook.test.started", new Object[]{scenario.getName()}));
+        log.info(parser.parse("hook.test.build"));
         spec = new RequestSpecBuilder()
                 .setContentType(ContentType.JSON)
                 .setBaseUri(System.getProperty("endpoint"))
@@ -27,8 +30,8 @@ public class Hook extends Spec {
 
     @After
     public void end(Scenario scenario){
-        log.info(String.format("TESTE FINALIZADO: %s",scenario.getName()));
-        log.info(String.format("TESTE STATUS: %s",scenario.getStatus()));
+        log.info(parser.parse("hook.test.ended", new Object[]{scenario.getName()}));
+        log.info(parser.parse("hook.test.status", new Object[]{scenario.getStatus()}));
     }
 }
 


### PR DESCRIPTION
* Novo pacote de idiomas para mensagens de log
* Suporte a `pt-BR` e `en-US`
* Controle feito pela property `language` do arquivo `log4j2.properties`. `pt-BR` definido por padrão